### PR TITLE
INFRA-183. adding script to provision RDS databases for DataGuard.

### DIFF
--- a/rds/configure_rds_mysql_parameter_group.sh
+++ b/rds/configure_rds_mysql_parameter_group.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+export AWS_DEFAULT_OUTPUT="json"
+
+TARGET_PARAM_GROUP=$1
+
+apply_param () {
+  aws rds modify-db-parameter-group --db-parameter-group-name $1 --parameters "ParameterName=$2,ParameterValue=$3,ApplyMethod=immediate"
+}
+
+apply_param $TARGET_PARAM_GROUP general_log 1
+apply_param $TARGET_PARAM_GROUP slow_query_log 1
+apply_param $TARGET_PARAM_GROUP log_output FILE

--- a/rds/configure_rds_postgresql_parameter_group.sh
+++ b/rds/configure_rds_postgresql_parameter_group.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+export AWS_DEFAULT_OUTPUT="json"
+
+TARGET_PARAM_GROUP=$1
+
+apply_param () {
+  aws rds modify-db-parameter-group --db-parameter-group-name $1 --parameters "ParameterName=$2,ParameterValue=$3,ApplyMethod=immediate"
+}
+
+apply_param $TARGET_PARAM_GROUP log_transaction_sample_rate 0.1

--- a/rds/modify_rds_for_datguard.sh
+++ b/rds/modify_rds_for_datguard.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -e
+
+export AWS_DEFAULT_OUTPUT="json"
+
+WANTED_TAG=dataguard
+WANTED_VALUE=monitored
+
+if [[ ! $@ ]]; then
+   DB_INSTANCES=$(aws resourcegroupstaggingapi get-resources --resource-type-filters rds:db \
+    --query ResourceTagMappingList[].ResourceARN --output=text --tag-filters Key=$WANTED_TAG,Values=$WANTED_VALUE)
+else
+   DB_INSTANCES=$@
+fi
+
+apply_param () {
+  aws rds modify-db-parameter-group --db-parameter-group-name $1 --parameters "ParameterName=$2,ParameterValue=$3,ApplyMethod=immediate"
+}
+
+for db in $DB_INSTANCES; do
+
+  instanceid=$(echo $db | sed 's/^.*://g')
+    metadata=$(aws rds describe-db-instances --db-instance-identifier $instanceid)
+  paramgroup=$(echo $metadata | jq -r '.DBInstances[0].DBParameterGroups[0].DBParameterGroupName')
+
+  export TARGET_PARAM_GROUP=$paramgroup
+
+  if [[ "$paramgroup" == *"default"* ]] && [[ "$paramgroup" != *"dataguard"* ]]; then
+    export TARGET_PARAM_GROUP=dataguard-$instanceid
+    family=$(aws rds describe-db-parameter-groups --db-parameter-group-name $paramgroup \
+      --query DBParameterGroups[0].DBParameterGroupFamily | jq -r)
+    group_exists=$(aws rds  describe-db-parameter-groups --query 'DBParameterGroups[].DBParameterGroupName' | grep $TARGET_PARAM_GROUP)
+    if [[ ! $group_exists ]];then
+      echo "Creating new parameter group: $TARGET_PARAM_GROUP"
+      aws rds create-db-parameter-group --db-parameter-group-name $TARGET_PARAM_GROUP --db-parameter-group-family $family --description "dataguard parameter group"
+    fi
+    echo "Rebooting $instanceid with new parameter group: $TARGET_PARAM_GROUP"
+    aws rds modify-db-instance --db-instance-identifier $instanceid --db-parameter-group-name $TARGET_PARAM_GROUP --apply-immediately > /dev/null
+    echo "Waiting for $instanceid to become available again"
+    aws rds wait db-instance-available --db-instance-identifier $instanceid
+  fi
+
+  aws rds wait db-instance-available --db-instance-identifier $instanceid
+
+  echo "Updating parameters"
+  apply_param $TARGET_PARAM_GROUP general_log 1
+  apply_param $TARGET_PARAM_GROUP slow_query_log 1
+  apply_param $TARGET_PARAM_GROUP log_output FILE
+
+  echo "Enabling export logs on $instanceid"
+
+  aws rds wait db-instance-available --db-instance-identifier $instanceid
+
+  ORIG_TYPES=$(echo $metadata | jq '.DBInstances[0].EnabledCloudwatchLogsExports[]' | tr '\n' ',' | sed 's/,$//g') || " "
+  TYPES=$ORIG_TYPES
+
+      error_good=$(echo $TYPES | grep error)
+    general_good=$(echo $TYPES | grep general)
+  slowquery_good=$(echo $TYPES | grep slowquery)
+
+  if [[ ! $error_good ]]; then
+     export TYPES=$TYPES,\"error\"
+  fi
+
+  if [[ ! $general_good ]]; then
+     export TYPES=$TYPES,\"general\"
+  fi
+
+  if [[ ! $slowquery_good ]]; then
+     export TYPES=$TYPES,\"slowquery\"
+  fi
+
+  export TYPES=$(echo $TYPES | sed 's/^,//g')
+
+  if [[ ! $ORIG_TYPES == $TYPES ]]; then
+    echo "Applying instance enabled log types"
+    COMMAND=$(echo aws rds modify-db-instance --db-instance-identifier $instanceid --cloudwatch-logs-export-configuration \'{\"EnableLogTypes\":[ $TYPES ]}\')
+    eval $COMMAND >> /dev/null
+    aws rds wait db-instance-available --db-instance-identifier $instanceid
+  else
+    echo "Export log types properly configured"
+  fi
+
+done

--- a/rds/modify_rds_mysql_for_datguard.sh
+++ b/rds/modify_rds_mysql_for_datguard.sh
@@ -1,0 +1,101 @@
+#!/bin/bash -e
+
+export AWS_DEFAULT_OUTPUT="json"
+
+WANTED_TAG=dataguard
+WANTED_VALUE=monitored
+
+if [[ ! $@ ]]; then
+   DB_INSTANCES=$(aws resourcegroupstaggingapi get-resources --resource-type-filters rds:db \
+    --query ResourceTagMappingList[].ResourceARN --output=text --tag-filters Key=$WANTED_TAG,Values=$WANTED_VALUE)
+else
+   DB_INSTANCES=$@
+fi
+
+apply_param () {
+  aws rds modify-db-parameter-group --db-parameter-group-name $1 --parameters "ParameterName=$2,ParameterValue=$3,ApplyMethod=immediate"
+}
+
+
+apply_immediately? () {
+  read -p "Do you apply this immediately?" yn
+  case $yn in
+      [Yy]* ) break;;
+      [Nn]* ) exit 1;;
+      * ) echo "Please answer yes or no.";;
+  esac
+}
+
+
+
+for db in $DB_INSTANCES; do
+
+  instanceid=$(echo $db | sed 's/^.*://g')
+    metadata=$(aws rds describe-db-instances --db-instance-identifier $instanceid)
+  paramgroup=$(echo $metadata | jq -r '.DBInstances[0].DBParameterGroups[0].DBParameterGroupName')
+
+  export TARGET_PARAM_GROUP=$paramgroup
+
+  if [[ "$paramgroup" == *"default"* ]] && [[ "$paramgroup" != *"dataguard"* ]]; then
+    export TARGET_PARAM_GROUP=dataguard-$instanceid
+    family=$(aws rds describe-db-parameter-groups --db-parameter-group-name $paramgroup \
+      --query DBParameterGroups[0].DBParameterGroupFamily | jq -r)
+    group_exists=$(aws rds  describe-db-parameter-groups --query 'DBParameterGroups[].DBParameterGroupName' | grep $TARGET_PARAM_GROUP)
+    if [[ ! $group_exists ]];then
+      echo "Creating new parameter group: $TARGET_PARAM_GROUP"
+      aws rds create-db-parameter-group --db-parameter-group-name $TARGET_PARAM_GROUP --db-parameter-group-family $family --description "dataguard parameter group"
+    fi
+    echo "Applying new parameter group to $instanceid: $TARGET_PARAM_GROUP"
+    apply_immediately?
+    aws rds modify-db-instance --db-instance-identifier $instanceid --db-parameter-group-name $TARGET_PARAM_GROUP --apply-immediately > /dev/null
+    echo "Waiting for $instanceid to become available again"
+    aws rds wait db-instance-available --db-instance-identifier $instanceid
+  elif [[ ! "$paramgroup" == *"default"* ]] && [[ "$paramgroup" != *"dataguard"* ]]; then
+    echo "Copying customized parameter group to modify"
+    aws rds copy-db-parameter-group --source-db-parameter-group-identifier "$paramgroup" --target-db-parameter-group-identifier $TARGET_PARAM_GROUP
+    apply_immediately?
+    aws rds modify-db-instance --db-instance-identifier $instanceid --db-parameter-group-name $TARGET_PARAM_GROUP --apply-immediately > /dev/null
+  fi
+
+  aws rds wait db-instance-available --db-instance-identifier $instanceid
+
+  echo "Updating parameters"
+  apply_param $TARGET_PARAM_GROUP general_log 1
+  apply_param $TARGET_PARAM_GROUP slow_query_log 1
+  apply_param $TARGET_PARAM_GROUP log_output FILE
+
+  echo "Enabling export logs on $instanceid"
+
+  aws rds wait db-instance-available --db-instance-identifier $instanceid
+
+  ORIG_TYPES=$(echo $metadata | jq '.DBInstances[0].EnabledCloudwatchLogsExports[]' | tr '\n' ',' | sed 's/,$//g') || " "
+  TYPES=$ORIG_TYPES
+
+      error_good=$(echo $TYPES | grep error)
+    general_good=$(echo $TYPES | grep general)
+  slowquery_good=$(echo $TYPES | grep slowquery)
+
+  if [[ ! $error_good ]]; then
+     export TYPES=$TYPES,\"error\"
+  fi
+
+  if [[ ! $general_good ]]; then
+     export TYPES=$TYPES,\"general\"
+  fi
+
+  if [[ ! $slowquery_good ]]; then
+     export TYPES=$TYPES,\"slowquery\"
+  fi
+
+  export TYPES=$(echo $TYPES | sed 's/^,//g')
+
+  if [[ ! $ORIG_TYPES == $TYPES ]]; then
+    echo "Applying instance enabled log types"
+    COMMAND=$(echo aws rds modify-db-instance --db-instance-identifier $instanceid --cloudwatch-logs-export-configuration \'{\"EnableLogTypes\":[ $TYPES ]}\')
+    eval $COMMAND >> /dev/null
+    aws rds wait db-instance-available --db-instance-identifier $instanceid
+  else
+    echo "Export log types properly configured"
+  fi
+
+done


### PR DESCRIPTION
### Description

This script configures parameter groups and log exports for RDS instances. Supports either tagging instances or just specifying the instance IDs as an argument. 

### Testing

First, create an RDS instance of any variety. Then test the following:

* Run script against database, verify that new parameter group is created and attached to the RDS instance
* Create a custom parameter group, attach it to the RDS instance, delete the old parameter group, rerun the script and verify that it does not create a new parameter group, verify that the parameters are correct in the existing group
* Create a few RDS instances, tag them with the key dataguard and value monitored, run the script and verify that the parameter groups are created and attached to the instances.